### PR TITLE
Add prototype for ps2link_response_getstat, fix compile warning

### DIFF
--- a/src/ps2link.c
+++ b/src/ps2link.c
@@ -584,13 +584,14 @@ int ps2link_request_getstat(void *packet) {
   struct { unsigned int number; unsigned short length; char name[256]; } PACKED *request = packet;
     struct stat stats; struct tm *loctime;
     int ret;
-    unsigned int mode; unsigned char ctime[8]; unsigned char atime[8]; unsigned char mtime[8];
+    unsigned int mode = 0;
+    unsigned char ctime[8]; unsigned char atime[8]; unsigned char mtime[8];
 
     // Fix the arguments.
     fix_pathname(request->name);
     
-      // Fetch the entry's statistics.
-      ret = stat(request->name, &stats);
+    // Fetch the entry's statistics.
+    ret = stat(request->name, &stats);
     
     if (ret == 0) {
         // Convert the mode.

--- a/src/ps2link.h
+++ b/src/ps2link.h
@@ -133,6 +133,17 @@
 
  int ps2link_response_rmdir(int result);
 
+ int ps2link_response_getstat(
+   int result,
+   unsigned int mode,
+   unsigned int attr,
+   unsigned int size,
+   unsigned char *ctime,
+   unsigned char *atime,
+   unsigned char *mtime,
+   unsigned int hisize
+);
+
  //////////////////////////////
  // PS2LINK THREAD FUNCTIONS //
  //////////////////////////////


### PR DESCRIPTION
Fixes these diagnostics when compiling with clang 12:

`src/ps2link.c:632:12: error: implicit declaration of function 'ps2link_response_getstat' is invalid in C99 [-Werror,-Wimplicit-function-declaration]`

```
src/ps2link.c:595:9: warning: variable 'mode' is used uninitialized whenever 'if' condition is false [-Wsometimes-uninitialized]
src/ps2link.c:632:42: note: uninitialized use occurs here
src/ps2link.c:595:5: note: remove the 'if' if its condition is always true
src/ps2link.c:587:22: note: initialize the variable 'mode' to silence this warning
```