### PR TITLE
Fix mingw32 build: cast setsockopt optval to const char *

### DIFF
--- a/src/ps2link.c
+++ b/src/ps2link.c
@@ -58,7 +58,7 @@
   // ~200 ms stall per read() syscall, making fread() ~400x slower than read().
   if (request_socket > 0) {
     int one = 1;
-    setsockopt(request_socket, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
+    setsockopt(request_socket, IPPROTO_TCP, TCP_NODELAY, (const char *)&one, sizeof(one));
   }
 
   // Create the request thread.


### PR DESCRIPTION
## Summary
- PR #22 added a `setsockopt(..., TCP_NODELAY, &one, sizeof(one))` call that breaks the mingw32 build because Winsock's `setsockopt` prototype takes `const char *optval` (not `const void *` like POSIX).
- Adds a `(const char *)` cast — harmless on POSIX, required on Windows.

This is what currently fails CI on `windows-latest` in the ps2dev meta build:

```
src/ps2link.c:61:58: error: passing argument 4 of 'setsockopt' from incompatible pointer type [-Wincompatible-pointer-types]
   61 |     setsockopt(request_socket, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
note: expected 'const char *' but argument is of type 'int *'
make[1]: *** [Makefile.mingw32:26: obj/ps2link.o] Error 1
```

## Test plan
- [ ] CI green on Linux/macOS (unchanged behavior — cast is a no-op on POSIX where `optval` is `const void *`)
- [ ] CI green on Windows / mingw32

🤖 Generated with [Claude Code](https://claude.com/claude-code)