### PR TITLE
Set TCP_NODELAY on the ps2link request socket

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -5,6 +5,7 @@
  #include <sys/socket.h>
  #include <sys/time.h>
  #include <netinet/in.h>
+ #include <netinet/tcp.h>
 #endif
 
  #include "network.h"
@@ -35,6 +36,15 @@
 
   // Open the socket.
   sock = socket(AF_INET, type, 0); if (sock < 0) { return -1; }
+
+  // Disable Nagle on the request channel: ps2link's fileio is a synchronous
+  // sequence of small request/response exchanges, and Nagle on this side
+  // colliding with the PS2's delayed ACKs stalls every exchange ~200ms
+  // (observed ~4 KB/s file serving; with TCP_NODELAY it is wire-speed).
+  if (type == SOCK_STREAM) {
+   int nodelay = 1;
+   setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, (void *)&nodelay, sizeof(nodelay));
+  }
 
   // Connect the socket.
   if (connect(sock, (struct sockaddr *)&sockaddr, sizeof(struct sockaddr)) < 0) { return -2; }


### PR DESCRIPTION
## Problem

ps2link fileio is a synchronous sequence of small request/response exchanges over the TCP request channel (port 0x4711). With Nagle enabled on the client side, each response collides with the PS2 stack delayed ACKs and stalls roughly one delayed-ACK period (~200 ms) per exchange.

Measured effect (PAL console, 100 Mbit ethernet, Windows host, ps2link v1.9.1): file serving capped at about **4 KB/s** - a 424 KB texture took 106 seconds, and a homebrew game loading all of its assets over `host:` took 10 minutes to boot.

## Fix

Set `TCP_NODELAY` on the `SOCK_STREAM` connect path in `network_connect()` (UDP sockets unaffected). Small responses then leave immediately instead of waiting for the ACK of the previous segment.

With the patch, the same texture serves in about a second and the same game boots in ~30 seconds; streaming 22 kHz PCM music over `host:` becomes usable. Verified on real hardware against ps2link v1.9.1; behaviour on Linux/macOS builds is the same code path (`netinet/tcp.h` include added for those platforms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)